### PR TITLE
port to jenkins 2.0 and SimpleBuildWrapper to enable use in pipelines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509.4</version>
+    <version>2.0</version>
   </parent>
 
   <artifactId>livescreenshot</artifactId>
@@ -40,6 +40,14 @@
       <url>http://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
 
   <scm>
     <connection>scm:git:ssh://github.com/jenkinsci/livescreenshot-plugin.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.0</version>
+    <version>2.17</version>
   </parent>
 
   <artifactId>livescreenshot</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotAction.java
+++ b/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotAction.java
@@ -87,7 +87,7 @@ public class LiveScreenshotAction implements Action {
 		}
 			
 		// load image
-		byte[] bytes = new byte[0];
+		byte[] bytes;
 		try {
 			bytes = screenshot(filename);
 		}

--- a/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotAction.java
+++ b/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotAction.java
@@ -124,7 +124,11 @@ public class LiveScreenshotAction implements Action {
 	
 	public byte[] noScreenshotFile() throws IOException {
 		InputStream is = this.getClass().getResourceAsStream("noscreenshot.png");
-		return this.readContent(is, is.available());
+		try {
+			return this.readContent(is, is.available());
+		} finally {
+			is.close();
+		}
 	}
 	
 	public byte[] screenshotArtifact(String filename) throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotAction.java
+++ b/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotAction.java
@@ -152,7 +152,10 @@ public class LiveScreenshotAction implements Action {
 			}
 			InputStream is = fp.read();
 			byte[] bytes = readContent(is, fp.length());
-			is.read(bytes);
+			int read = 0;
+			while (read != fp.length() && read != -1) {
+				read += is.read(bytes);
+			}
 			return bytes;
 		}
 		catch (InterruptedException ex) {

--- a/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotAction.java
+++ b/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotAction.java
@@ -1,26 +1,42 @@
+/**
+ * Copyright 2013 Dr. Stefan Schimanski <sts@1stein.org>
+ * Copyright 2017 Harald Sitter <sitter@kde.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.jenkinsci.plugins.livescreenshot;
 
 import hudson.FilePath;
-import hudson.model.AbstractBuild;
 import hudson.model.Action;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-
-import javax.servlet.ServletOutputStream;
-
+import hudson.model.Run;
+import jenkins.util.VirtualFile;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+
+import javax.servlet.ServletOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * @author sts
  */
 public class LiveScreenshotAction implements Action {
-	private AbstractBuild build;
+	private Run<?,?> build;
 	private final String fullscreenFilename;
 	private final String thumbnailFilename;
+	private FilePath workspace;
 	
 	public String getFullscreenFilename() {
 		return fullscreenFilename;
@@ -30,13 +46,14 @@ public class LiveScreenshotAction implements Action {
 		return thumbnailFilename;
 	}
 	
-	public LiveScreenshotAction(AbstractBuild build, String fullscreenFilename, String thumbnailFilename) {
+	public LiveScreenshotAction(Run<?,?> build, FilePath workspace, String fullscreenFilename, String thumbnailFilename) {
 		this.build = build;
+		this.workspace = workspace;
 		this.fullscreenFilename = fullscreenFilename;
 		this.thumbnailFilename = thumbnailFilename;
 	}
 
-	public AbstractBuild getBuild() {
+	public Run<?, ?> getBuild() {
 		return this.build;
 	}
 	
@@ -50,6 +67,10 @@ public class LiveScreenshotAction implements Action {
 
 	public String getUrlName() {
 		return "screenshot";
+	}
+
+	public FilePath getWorkspace() {
+		return this.workspace;
 	}
 
 	public void doDynamic(StaplerRequest request, StaplerResponse rsp)
@@ -107,12 +128,9 @@ public class LiveScreenshotAction implements Action {
 	}
 	
 	public byte[] screenshotArtifact(String filename) throws IOException {
-		// does artifact exist?
-		String path = this.build.getArtifactsDir().getCanonicalPath() + "/screenshots";
-		File file = new File(path + "/" + filename);
+		VirtualFile file = build.getArtifactManager().root().child("screenshots/"+filename);
 		if (file.isFile()) {
-			// return artifact file
-			FileInputStream fis = new FileInputStream(file);
+			InputStream fis = file.open();
 			byte[] bytes = readContent(fis, file.length());
 			fis.close();
 			return bytes;
@@ -124,7 +142,7 @@ public class LiveScreenshotAction implements Action {
 	public byte[] liveScreenshot(String filename) throws IOException {
 		try {
 			// return workspace file
-			FilePath fp = build.getWorkspace().child(filename);
+			FilePath fp = workspace.child(filename);
 			if (!fp.exists()) {
 				return this.noScreenshotFile();
 			}
@@ -143,7 +161,7 @@ public class LiveScreenshotAction implements Action {
 		byte[] bytes = screenshotArtifact(filename);
 		if (bytes != null)
 			return bytes;
-				
+
 		return liveScreenshot(filename);
 	}
 }

--- a/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotColumn.java
@@ -58,13 +58,12 @@ public class LiveScreenshotColumn extends ListViewColumn {
 		} else {
 			// add screenshot of current job
 			if (run.isBuilding()) {
-				html = html + "<a href=\"" + run.getUrl() + "screenshot\">" +
-						"<img src=\"" + run.getUrl() + "screenshot/thumb\" /></a>";
+				html = html + "<a href=\"/" + run.getUrl() + "screenshot\">" +
+						"<img src=\"/" + run.getUrl() + "screenshot/thumb\" /></a>";
 			}
 		}
 		return html;
 	}
-	
 
 	public String getScreenshots(Job job) {
 		// collect screenshot link strings for all active builds

--- a/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotColumn.java
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2013 Dr. Stefan Schimanski <sts@1stein.org>
+ * Copyright 2017 Harald Sitter <sitter@kde.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.jenkinsci.plugins.livescreenshot;
 
 import hudson.Extension;
@@ -35,11 +53,13 @@ public class LiveScreenshotColumn extends ListViewColumn {
 		if (run instanceof MatrixBuild) {
 			MatrixBuild mb = (MatrixBuild)run;
 			List<MatrixRun> childRuns = mb.getRuns();
+			StringBuffer buf = new StringBuffer();
 			for (MatrixRun child : childRuns) {
-				html = html + collectScreenshots(child);
+				buf.append(collectScreenshots(child));
 			}
+			html += buf.toString();
 		} else {
-			// add screenshot of current job	
+			// add screenshot of current job
 			if (run.isBuilding()) {
 				html = html + "<a href=\"" + run.getUrl() + "screenshot\">" +
 						"<img src=\"" + run.getUrl() + "screenshot/thumb\" /></a>";
@@ -67,19 +87,19 @@ public class LiveScreenshotColumn extends ListViewColumn {
 		}
 		
 		// one row for each job
-		String s = "";
+		StringBuffer buf = new StringBuffer();
 		for (Map.Entry<AbstractBuild, String> pair : runScreenshotStrings.entrySet()) {
 			// newline?
-			if (!s.isEmpty()) {
-				s += "<br/><br/>";
+			if (buf.length() != 0) {
+				buf.append("<br/><br/>");
 			}
 			
 			// first the screenshots
-			s += pair.getValue();
+			buf.append(pair.getValue());
 
 			// then the line with the "stop" link and the changelog
 			AbstractBuild r = pair.getKey();
-			s += "<br/><a href=\"" + r.getUrl() + "\">" + r.getDisplayName() + "</a> ";
+			buf.append("<br/><a href=\"" + r.getUrl() + "\">" + r.getDisplayName() + "</a> ");
 
 			// create link to executor stop action, or the oneOffExecutor for MatrixBuilds
 			Executor executor = null;
@@ -92,27 +112,27 @@ public class LiveScreenshotColumn extends ListViewColumn {
 			if (executor != null) {
 				Computer computer = executor.getOwner();
 				if (computer != null) {
-					s += "<a href=\"" + computer.getUrl() + 
+					buf.append("<a href=\"" + computer.getUrl() +
 							(isOneOffExecutor ? "oneOffExecutors" : "executors") +
-							"/" + 
+							"/" +
 							(isOneOffExecutor ? computer.getOneOffExecutors().indexOf(executor) : executor.getNumber()) +
-							"/stop\">Stop</a> ";
+							"/stop\">Stop</a> ");
 				}
 			}
-			
+
 			// append changelog entries
 			ChangeLogSet<? extends Entry> changeLogSet = r.getChangeSet();
 			if (changeLogSet != null) {
 				for (Object o : changeLogSet.getItems()) {
 					if (o instanceof ChangeLogSet.Entry) {
-						ChangeLogSet.Entry e = (ChangeLogSet.Entry)o;
-						s += " - " + e.getMsgAnnotated();
+						ChangeLogSet.Entry e = (ChangeLogSet.Entry) o;
+						buf.append(" - " + e.getMsgAnnotated());
 					}
 				}
 			}
 		}
 		
-        return s;
+        return buf.toString();
     }
     
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotColumn.java
@@ -1,6 +1,6 @@
 /**
  * Copyright 2013 Dr. Stefan Schimanski <sts@1stein.org>
- * Copyright 2017 Harald Sitter <sitter@kde.org>
+ * Copyright 2017-2018 Harald Sitter <sitter@kde.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -21,20 +21,17 @@ package org.jenkinsci.plugins.livescreenshot;
 import hudson.Extension;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixRun;
-import hudson.model.AbstractBuild;
-import hudson.model.Computer;
-import hudson.model.Executor;
-import hudson.model.Job;
-import hudson.model.Run;
+import hudson.model.*;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.Entry;
 import hudson.util.RunList;
 import hudson.views.ListViewColumn;
 import hudson.views.ListViewColumnDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  *
@@ -68,12 +65,13 @@ public class LiveScreenshotColumn extends ListViewColumn {
 		return html;
 	}
 	
-    public String getScreenshots(Job job) {
+
+	public String getScreenshots(Job job) {
 		// collect screenshot link strings for all active builds
 		RunList runs = job.getBuilds();
-		HashMap<AbstractBuild, String> runScreenshotStrings = new HashMap<AbstractBuild, String>();
+		HashMap<Build, String> runScreenshotStrings = new HashMap<Build, String>();
 		for (Object o : runs) {
-			AbstractBuild b = (AbstractBuild)o;
+			Build b = (Build)o;
 			if (!b.isBuilding())
 				continue;
 			String rs = this.collectScreenshots(b);
@@ -84,11 +82,13 @@ public class LiveScreenshotColumn extends ListViewColumn {
 			} else {
 				runScreenshotStrings.put(b, rs);
 			}
+
+
 		}
-		
+
 		// one row for each job
 		StringBuffer buf = new StringBuffer();
-		for (Map.Entry<AbstractBuild, String> pair : runScreenshotStrings.entrySet()) {
+		for (Map.Entry<Build, String> pair : runScreenshotStrings.entrySet()) {
 			// newline?
 			if (buf.length() != 0) {
 				buf.append("<br/><br/>");
@@ -98,7 +98,7 @@ public class LiveScreenshotColumn extends ListViewColumn {
 			buf.append(pair.getValue());
 
 			// then the line with the "stop" link and the changelog
-			AbstractBuild r = pair.getKey();
+			Build r = pair.getKey();
 			buf.append("<br/><a href=\"" + r.getUrl() + "\">" + r.getDisplayName() + "</a> ");
 
 			// create link to executor stop action, or the oneOffExecutor for MatrixBuilds

--- a/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotDisposer.java
+++ b/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotDisposer.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2017 Harald Sitter <sitter@kde.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jenkinsci.plugins.livescreenshot;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkins.tasks.SimpleBuildWrapper;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class LiveScreenshotDisposer extends SimpleBuildWrapper.Disposer {
+    private static final long serialVersionUID = 1L;
+
+    private final String fullscreenFilename;
+    private final String thumbnailFilename;
+
+    public LiveScreenshotDisposer(final String fullscreenFilename, final String thumbnailFilename) {
+        this.fullscreenFilename = fullscreenFilename;
+        this.thumbnailFilename = thumbnailFilename;
+    }
+
+    @Override
+    public void tearDown(final Run<?, ?> build, final FilePath workspace, final Launcher launcher, final TaskListener listener) throws IOException, InterruptedException {
+        Map<String, String> map = new HashMap<>();
+        map.put("screenshots/" + fullscreenFilename, fullscreenFilename);
+        map.put("screenshots/" + thumbnailFilename, thumbnailFilename);
+        build.getArtifactManager().archive(workspace, launcher, null, map);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotDisposer.java
+++ b/src/main/java/org/jenkinsci/plugins/livescreenshot/LiveScreenshotDisposer.java
@@ -41,8 +41,14 @@ public class LiveScreenshotDisposer extends SimpleBuildWrapper.Disposer {
     @Override
     public void tearDown(final Run<?, ?> build, final FilePath workspace, final Launcher launcher, final TaskListener listener) throws IOException, InterruptedException {
         Map<String, String> map = new HashMap<>();
-        map.put("screenshots/" + fullscreenFilename, fullscreenFilename);
-        map.put("screenshots/" + thumbnailFilename, thumbnailFilename);
+
+        if (fullscreenFilename != null) {
+            map.put("screenshots/" + fullscreenFilename, fullscreenFilename);
+        }
+        if (thumbnailFilename != null) {
+            map.put("screenshots/" + thumbnailFilename, thumbnailFilename);
+        }
+
         build.getArtifactManager().archive(workspace, launcher, null, map);
     }
 }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the installed plugins page.
 -->

--- a/src/main/resources/org/jenkinsci/plugins/livescreenshot/LiveScreenshotAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/livescreenshot/LiveScreenshotAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
 	<j:set var="build" value="${it.build}" />
 	<l:layout title="${build} Screenshot" norefresh="false">

--- a/src/main/resources/org/jenkinsci/plugins/livescreenshot/LiveScreenshotBuildWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/livescreenshot/LiveScreenshotBuildWrapper/config.jelly
@@ -1,4 +1,5 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" 
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:entry title="Full size screenshot filename" field="fullscreenFilename">
 		<f:textbox default="screenshot.png"/>

--- a/src/main/resources/org/jenkinsci/plugins/livescreenshot/LiveScreenshotColumn/column.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/livescreenshot/LiveScreenshotColumn/column.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <td>${it.getScreenshots(job)}</td>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/livescreenshot/LiveScreenshotColumn/column.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/livescreenshot/LiveScreenshotColumn/column.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-    <td>${it.getScreenshots(job)}</td>
+    <td><j:out value="${it.getScreenshots(job)}"/></td>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/livescreenshot/LiveScreenshotColumn/columnHeader.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/livescreenshot/LiveScreenshotColumn/columnHeader.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <th>Screenshots</th>
 </j:jelly>


### PR DESCRIPTION
pipelines have a generic `wrap` step which allows using any wrapper in
a Jenkinsfile so long as the wrapper implements SimpleBuildWrapper.

given the simplicity of the livescreenshot wrapper this is easily achieved
by moving away from deprecated artifact management and introduction of
a new disposer to handle auto-archiving.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/livescreenshot-plugin/1)
<!-- Reviewable:end -->
